### PR TITLE
add feature to navigate blocks with up/down arrows

### DIFF
--- a/packages/@xelah-core/package.json
+++ b/packages/@xelah-core/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "use-deep-compare": "^1.1.0",
-    "contenteditable-arrow-navigation": "^0.2.0"
+    "contenteditable-arrow-navigation": "^0.3.0"
   },
   "scripts": {
     "start": "yarn && styleguidist server",

--- a/packages/@xelah-core/package.json
+++ b/packages/@xelah-core/package.json
@@ -9,7 +9,8 @@
     "url": "https://github.com/xelahjs/xelah.git"
   },
   "dependencies": {
-    "use-deep-compare": "^1.1.0"
+    "use-deep-compare": "^1.1.0",
+    "contenteditable-arrow-navigation": "^0.1.4"
   },
   "scripts": {
     "start": "yarn && styleguidist server",

--- a/packages/@xelah-core/package.json
+++ b/packages/@xelah-core/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "use-deep-compare": "^1.1.0",
-    "contenteditable-arrow-navigation": "^0.1.4"
+    "contenteditable-arrow-navigation": "^0.1.5"
   },
   "scripts": {
     "start": "yarn && styleguidist server",

--- a/packages/@xelah-core/package.json
+++ b/packages/@xelah-core/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "use-deep-compare": "^1.1.0",
-    "contenteditable-arrow-navigation": "^0.1.5"
+    "contenteditable-arrow-navigation": "^0.2.0"
   },
   "scripts": {
     "start": "yarn && styleguidist server",

--- a/packages/@xelah-core/src/components/EditableContent.jsx
+++ b/packages/@xelah-core/src/components/EditableContent.jsx
@@ -2,7 +2,8 @@
 /* eslint-disable react/display-name */
 import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { useDeepCompareCallback, useDeepCompareMemo } from 'use-deep-compare';
+import { useDeepCompareCallback, useDeepCompareEffect, useDeepCompareMemo } from 'use-deep-compare';
+import { addArrowKeyNavigationToContenteditableElements } from 'contenteditable-arrow-navigation';
 
 import useParseSectionsContent from '../hooks/useParseSectionsContent';
 import { isRtl } from '../helpers/detectRTL';
@@ -52,8 +53,14 @@ export default function EditableContent({
   const options = { ...DEFAULT_PROPS.options, ...props.options };
   const handlers = { ...DEFAULT_PROPS.handlers, ...props.handlers };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { if (verbose) console.log('EditableContent First Render'); }, []);
+  useEffect(() => {
+    if (verbose) console.log('EditableContent First Render');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useDeepCompareEffect(() => {
+    addArrowKeyNavigationToContenteditableElements();
+  }, [options, content]);
 
   const sectionsContent = useParseSectionsContent({ content, parsers, options })
 

--- a/packages/@xelah-core/src/hooks/useEditableBlockProps.js
+++ b/packages/@xelah-core/src/hooks/useEditableBlockProps.js
@@ -50,8 +50,10 @@ export default function useEditableBlockProps({
       _content = div.textContent.replaceAll(/&lt;/g, '<');
     };
 
-    if (content !== _content) onContent(_content);
-    setEditIndex(editIndex + 1);
+    if (content !== _content) {
+      onContent(_content);
+      setEditIndex(editIndex + 1);
+    };
   }, [returnHtml, content, onContent, editIndex]);
 
   const onBlur = useCallback((event) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,10 +3762,10 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-contenteditable-arrow-navigation@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.1.5.tgz#394c0e1f7df7b253fe7e359b2c556c66574ca717"
-  integrity sha512-sx2dt4tnh4GKwyEtNhPHvAHuXsGoLiSYQp8IZq+Gwd0js7DMhR2IXW4kUHj/2bRFnICyfrqDHqHrIysMsfCZtw==
+contenteditable-arrow-navigation@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.2.0.tgz#008fb64656047587a838389d7613483f31e6dd7a"
+  integrity sha512-JpfpcylECXYDawcgch300I0YzR9j9jmXCzvIM2t/mfTLWs597E2KXuwzhxG34dY/Hx454DuYirG32yQJahq4/A==
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,6 +3762,11 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
+contenteditable-arrow-navigation@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.1.4.tgz#95afa29f5921f3d836a46cd74fd8f556f74490e2"
+  integrity sha512-jcJEqB1XraCR5Luxfyceq6CllSxAA+cI7aF0WPoqacVUhAeVqsSnpZrbDGA9hWdYxTCoJiVBg5vuL0a+DOaGdA==
+
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,10 +3762,10 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-contenteditable-arrow-navigation@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.2.0.tgz#008fb64656047587a838389d7613483f31e6dd7a"
-  integrity sha512-JpfpcylECXYDawcgch300I0YzR9j9jmXCzvIM2t/mfTLWs597E2KXuwzhxG34dY/Hx454DuYirG32yQJahq4/A==
+contenteditable-arrow-navigation@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.3.0.tgz#c3b8b93c954c6c10b55cce3a1d93c327e0b19e19"
+  integrity sha512-pyrzpGEPDy6pyKYD5tyiQob1ZGGkieZUeYuFR2KRNjc02NCuy3+AyvV61cr2wsx5/LFaGCBaaM+mboVQdXjVCw==
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,10 +3762,10 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-contenteditable-arrow-navigation@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.1.4.tgz#95afa29f5921f3d836a46cd74fd8f556f74490e2"
-  integrity sha512-jcJEqB1XraCR5Luxfyceq6CllSxAA+cI7aF0WPoqacVUhAeVqsSnpZrbDGA9hWdYxTCoJiVBg5vuL0a+DOaGdA==
+contenteditable-arrow-navigation@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/contenteditable-arrow-navigation/-/contenteditable-arrow-navigation-0.1.5.tgz#394c0e1f7df7b253fe7e359b2c556c66574ca717"
+  integrity sha512-sx2dt4tnh4GKwyEtNhPHvAHuXsGoLiSYQp8IZq+Gwd0js7DMhR2IXW4kUHj/2bRFnICyfrqDHqHrIysMsfCZtw==
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"


### PR DESCRIPTION
My brother, @danielklapp and I have been working together to create a solution for allowing blocks to be navigable with up/down arrows as close to possible in behavior as turning blockable off. We think we have a temp solution... after the down arrow takes you to the end of the line, you press down arrow again and it navigates you to the next one. Same for up arrow. Basically pressing it an extra time will navigate like pressing tab or shift+tab. 

- Preview: https://deploy-preview-4--xelah-core.netlify.app/#editablecontent (turn off sectionable to play with it)
- NPM package: https://www.npmjs.com/package/contenteditable-arrow-navigation

This is a temp solution that we can work to improve. Ideally, but not sure if possible in browser, is to know when your are on the last rendered line of the html element and down arrow jumps to the same caret position in the first line of the next. The same behavior would be expected pressing the up arrow on the first rendered line to take you to the same caret position of the previous block.