### PR TITLE
Swap component order so apps can override components

### DIFF
--- a/packages/@xelah-type-perf-html/src/components/HtmlPerfEditor.jsx
+++ b/packages/@xelah-type-perf-html/src/components/HtmlPerfEditor.jsx
@@ -70,9 +70,9 @@ export default function HtmlPerfEditor({
     htmlSequence,
     onHtmlSequence,
     components: {
-      ...components,
       sectionHeading: (__props) => components.sectionHeading({ type: sequenceType, ...__props }),
       block: (__props) => RecursiveBlock({ htmlPerf, onHtmlPerf, sequenceIds, addSequenceId, ...__props }),
+      ...components,
     },
     options,
     handlers: {

--- a/packages/@xelah-type-perf-html/src/components/HtmlSequenceEditor.jsx
+++ b/packages/@xelah-type-perf-html/src/components/HtmlSequenceEditor.jsx
@@ -64,7 +64,6 @@ export default function HtmlSequenceEditor({
   const components = {
     document: (props) => Document({ nodes, verbose, ...props }),
     sectionHeading: SectionHeading,
-    // block: RecursiveBlock,
     ..._components
   };
 


### PR DESCRIPTION
I was trying to override the block component to add some listener to detect the current verse but it was impossible since the RecursiveBlock is always used.