### PR TITLE
moved defaultProps to Javascript default parameters

### DIFF
--- a/packages/@xelah-core/src/components/EditableBlock.jsx
+++ b/packages/@xelah-core/src/components/EditableBlock.jsx
@@ -28,18 +28,20 @@ A React component for editing any block, for instance a PERF Block.
 @todo refine prop types
 @see [PERF blocks]{@link https://doc.proskomma.bible/en/latest/__old/user_model/building_blocks.html#block} 
 */
-function EditableBlock({
-  content,
-  onContent,
-  decorators,
-  style,
-  onClick,
-  components: _components,
-  options,
-  index,
-  verbose = false,
-  ...props
-}) {
+function EditableBlock(editableBlockComponentProps) {
+  const {
+    content,
+    onContent,
+    decorators,
+    style,
+    onClick,
+    components: _components,
+    options,
+    index,
+    verbose = false,
+    ...props
+  } = editableBlockComponentProps;
+
   const components = { ...DEFAULT_PROPS.components, ..._components };
   const { block: Block } = components || {};
 

--- a/packages/@xelah-core/src/components/EditableContent.jsx
+++ b/packages/@xelah-core/src/components/EditableContent.jsx
@@ -36,17 +36,19 @@ const DEFAULT_PROPS = {
   sectionIndex: 0,
 };
 
-export default function EditableContent({
-  content,
-  onContent,
-  components: _components,
-  parsers,
-  joiners,
-  decorators,
-  sectionIndex,
-  verbose = false,
-  ...props
-}) {
+export default function EditableContent(editableContentProps) {
+  const {
+    content,
+    onContent,
+    components: _components,
+    parsers,
+    joiners,
+    decorators,
+    sectionIndex,
+    verbose = false,
+    ...props
+  } = editableContentProps;
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const components = useMemo(() => ({ ...DEFAULT_PROPS.components, ..._components }), []); // without empty dep for useMemo, components rerender from scratch every time.
   const { document: Document } = components;

--- a/packages/@xelah-core/src/components/EditableContextMenu.jsx
+++ b/packages/@xelah-core/src/components/EditableContextMenu.jsx
@@ -55,11 +55,13 @@ const DEFAULT_PROPS = {
   ],
 };
 
-export default function EditableContextMenu({
-  components: _components,
-  save,
-  children,
-}) {
+export default function EditableContextMenu(editableContextMenuProps) {
+  const {
+    components: _components,
+    save,
+    children,
+  } = editableContextMenuProps;
+  
   const defaultState = useMemo(
     () => ({
       menuPosition: undefined,

--- a/packages/@xelah-core/src/components/EditableSection.jsx
+++ b/packages/@xelah-core/src/components/EditableSection.jsx
@@ -34,19 +34,21 @@ const headingStyle = {
   contentOverflow: 'ellipsis',
 };
 
-export default function EditableSection({
-  content,
-  onContent,
-  parsers,
-  joiners,
-  decorators,
-  index,
-  onShow,
-  show,
-  dir,
-  verbose = false,
-  ...props
-}) {
+export default function EditableSection(editableSectionProps) {
+  const {
+    content,
+    onContent,
+    parsers,
+    joiners,
+    decorators,
+    index,
+    onShow,
+    show,
+    dir,
+    verbose = false,
+    ...props
+  } = editableSectionProps;
+
   const components = { ...DEFAULT_PROPS.components, ...props.components };
   const { section: Section, sectionHeading: SectionHeading, sectionBody: SectionBody } = components || {};
   const options = { ...DEFAULT_PROPS.options, ...props.options };

--- a/packages/@xelah-type-perf-html/src/components/Document.jsx
+++ b/packages/@xelah-type-perf-html/src/components/Document.jsx
@@ -1,14 +1,16 @@
 /* eslint-disable react/prop-types, no-unused-vars */
 import React, { useEffect } from 'react';
 
-export default function Document({
-  nodes = {},
-  children,
-  content: _content,
-  className: _className,
-  verbose,
-  ...props
-}) {
+export default function Document(documentProps) {
+  const {
+    nodes = {},
+    children,
+    content: _content,
+    className: _className,
+    verbose,
+    ...props
+  } = documentProps;
+
   useEffect(() => {
     if (verbose) console.log('Document: Mount/First Render');
     return (() => {

--- a/packages/@xelah-type-perf-html/src/components/HtmlPerfEditor.jsx
+++ b/packages/@xelah-type-perf-html/src/components/HtmlPerfEditor.jsx
@@ -11,16 +11,18 @@ import RecursiveBlock from "./RecursiveBlock";
 
 import HtmlSequenceEditor from "./HtmlSequenceEditor";
 
-export default function HtmlPerfEditor({
-  htmlPerf,
-  onHtmlPerf,
-  sequenceIds,
-  addSequenceId,
-  options,
-  components: _components,
-  handlers,
-  ...props
-}) {
+export default function HtmlPerfEditor(htmlPerfEditorProps) {
+  const {
+    htmlPerf,
+    onHtmlPerf,
+    sequenceIds,
+    addSequenceId,
+    options,
+    components: _components,
+    handlers,
+    ...props
+  } = htmlPerfEditorProps;
+
   const [sectionIndices, setSectionIndices] = useState({});
   const sequenceId = sequenceIds.at(-1);
 

--- a/packages/@xelah-type-perf-html/src/components/HtmlSequenceEditor.jsx
+++ b/packages/@xelah-type-perf-html/src/components/HtmlSequenceEditor.jsx
@@ -23,19 +23,21 @@ const DEFAULT_PROPS = {
   },
 };
 
-export default function HtmlSequenceEditor({
-  htmlSequence,
-  onHtmlSequence: _onHtmlSequence,
-  options: _options,
-  components: _components,
-  parsers: _parsers,
-  joiners: _joiners,
-  decorators: _decorators,
-  handlers,
-  sectionIndex,
-  verbose = false,
-  ...props
-}) {
+export default function HtmlSequenceEditor(htmlSequenceEditorProps) {
+  const {
+    htmlSequence,
+    onHtmlSequence: _onHtmlSequence,
+    options: _options,
+    components: _components,
+    parsers: _parsers,
+    joiners: _joiners,
+    decorators: _decorators,
+    handlers,
+    sectionIndex,
+    verbose = false,
+    ...props
+  } = htmlSequenceEditorProps;
+
   const decorators = { ...DEFAULT_PROPS.decorators, ..._decorators };
   const joiners = { ...DEFAULT_PROPS.joiners, ..._joiners };
 

--- a/packages/@xelah-type-perf-html/src/components/RecursiveBlock.jsx
+++ b/packages/@xelah-type-perf-html/src/components/RecursiveBlock.jsx
@@ -4,20 +4,22 @@ import React, { useEffect } from "react";
 import { getTarget } from "../core/getTarget";
 import HtmlPerfEditor from "./HtmlPerfEditor";
 
-export default function RecursiveBlock({
-  htmlPerf,
-  onHtmlPerf,
-  sequenceIds,
-  addSequenceId,
-  options,
-  content,
-  style,
-  contentEditable,
-  index,
-  verbose,
-  setFootNote,
-  ...props
-}) {
+export default function RecursiveBlock(recursiveBlockProps) {
+  const {
+    htmlPerf,
+    onHtmlPerf,
+    sequenceIds,
+    addSequenceId,
+    options,
+    content,
+    style,
+    contentEditable,
+    index,
+    verbose,
+    setFootNote,
+    ...props
+  } = recursiveBlockProps;
+
   useEffect(() => {
     if (verbose) console.log("Block: Mount/First Render", index);
     return () => {

--- a/packages/@xelah-type-perf-html/src/components/SectionHeading.jsx
+++ b/packages/@xelah-type-perf-html/src/components/SectionHeading.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
 
-// eslint-disable-next-line react/prop-types, no-unused-vars
-export default function SectionHeading({ type: _type, content, show, index, verbose, ...props }) {
+export default function SectionHeading(sectionHeadingProps) {
+  // eslint-disable-next-line react/prop-types, no-unused-vars
+  const { type: _type, content, show, index, verbose, ...props } = sectionHeadingProps;
+
   useEffect(() => {
     if (verbose) console.log('SectionHeading: Mount/First Render', index);
     return (() => {

--- a/packages/@xelah-type-perf-html/src/components/menuItems/FormatBlock.jsx
+++ b/packages/@xelah-type-perf-html/src/components/menuItems/FormatBlock.jsx
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 
 import { formatBlock, canFormatBlock } from '../../actions/formatBlock'
 
-export default function FormatBlock({label, subtype, sequence}) {
+export default function FormatBlock(formatBlockProps) {
+  const {label, subtype, sequence} = formatBlockProps;
 
   const [show, setShow] = useState( canFormatBlock( { sequence } ) );
   const handleSelectionChangeEvent = useCallback(() => {


### PR DESCRIPTION
The only changes made were to move defaultProps to Javascript default parameters, indented to eliminate the following warning: "Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead."

Thank you for your excellent work and contribution in making this monorepo available. I hope this tiny bit of pitching in will save you a little time at some point in the future!

For testing, both styleguides were loaded on local host without any console errors, with successful clicking around on buttons presented in default examples.
